### PR TITLE
Reusing Cases: The Case Macro Also Needed in Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ use rstest_reuse::{self, *};
 fn two_simple_cases(#[case] a: u32, #[case] b: u32) {}
 
 #[apply(two_simple_cases)]
-fn it_works(a: u32, b: u32) {
+fn it_works(#[case] a: u32, #[case] b: u32) {
     assert!(a == b);
 }
 ```


### PR DESCRIPTION
Hello,

Just a minor adjustment needed here regarding the usage of rstest_use.

The case macro is also needed in the test signature, as it was defined in the template, in order to fix the following compiler message:
"Wrong case signature: should match the given parameters list."

Thanks,
  Quenio