### PR TITLE
Allow awaiting futures automatically in parameters

### DIFF
--- a/rstest/tests/fixture/mod.rs
+++ b/rstest/tests/fixture/mod.rs
@@ -93,9 +93,11 @@ mod should {
         }
     }
 
-    #[test]
-    fn resolve_async_fixture() {
-        let prj = prj("async_fixture.rs");
+    #[rstest]
+    #[case::future("async_fixture.rs")]
+    #[case::await_future("await_fixture.rs")]
+    fn resolve_async_fixture(#[case] file: &str) {
+        let prj = prj(file);
         prj.add_dependency("async-std", r#"{version="*", features=["attributes"]}"#);
 
         let output = prj.run_tests().unwrap();

--- a/rstest/tests/resources/fixture/await_fixture.rs
+++ b/rstest/tests/resources/fixture/await_fixture.rs
@@ -1,0 +1,73 @@
+use std::io::prelude::*;
+
+use rstest::*;
+
+#[fixture]
+async fn async_u32() -> u32 {
+    42
+}
+
+#[fixture]
+async fn nest_fixture(#[await_future] async_u32: u32) -> u32 {
+    async_u32
+}
+
+#[fixture(fortytwo = async { 42 })]
+async fn nest_fixture_with_default(#[await_future] fortytwo: u32) -> u32 {
+    fortytwo
+}
+
+#[rstest]
+async fn default_is_async() {
+    assert_eq!(42, async_u32::default().await);
+}
+
+#[rstest]
+async fn use_async_nest_fixture_default(#[await_future] nest_fixture: u32) {
+    assert_eq!(42, nest_fixture);
+}
+
+#[rstest(nest_fixture(async { 24 }))]
+async fn use_async_nest_fixture_injected(#[await_future] nest_fixture: u32) {
+    assert_eq!(24, nest_fixture);
+}
+
+#[rstest]
+async fn use_async_nest_fixture_with_default(#[await_future] nest_fixture_with_default: u32) {
+    assert_eq!(42, nest_fixture_with_default);
+}
+
+#[rstest]
+async fn use_async_fixture(#[await_future] async_u32: u32) {
+    assert_eq!(42, async_u32);
+}
+
+#[fixture]
+async fn async_impl_output() -> impl Read {
+    std::io::Cursor::new(vec![1, 2, 3, 4, 5])
+}
+
+#[rstest]
+async fn use_async_impl_output<T: Read>(#[await_future] async_impl_output: T) {
+    let reader = async_impl_output;
+}
+
+#[fixture(four = async { 4 }, two = 2)]
+async fn two_args_mix_fixture(#[await_future] four: u32, two: u32) -> u32 {
+    four * 10 + two
+}
+
+#[rstest]
+async fn use_two_args_mix_fixture(#[await_future] two_args_mix_fixture: u32) {
+    assert_eq!(42, two_args_mix_fixture);
+}
+
+#[rstest(two_args_mix_fixture(async { 5 }))]
+async fn use_two_args_mix_fixture_inject_first(#[await_future] two_args_mix_fixture: u32) {
+    assert_eq!(52, two_args_mix_fixture);
+}
+
+#[rstest(two_args_mix_fixture(async { 3 }, 1))]
+async fn use_two_args_mix_fixture_inject_both(#[await_future] two_args_mix_fixture: u32) {
+    assert_eq!(31, two_args_mix_fixture);
+}

--- a/rstest/tests/resources/rstest/cases/await.rs
+++ b/rstest/tests/resources/rstest/cases/await.rs
@@ -1,0 +1,28 @@
+use rstest::*;
+
+#[rstest]
+#[case::pass(42, async { 42 })]
+#[case::fail(42, async { 41 })]
+#[should_panic]
+#[case::pass_panic(42, async { 41 })]
+#[should_panic]
+#[case::fail_panic(42, async { 42 })]
+async fn my_async_test(
+    #[case] expected: u32,
+    #[case]
+    #[await_future]
+    value: u32,
+) {
+    assert_eq!(expected, value);
+}
+
+#[rstest]
+#[case::pass(42, async { 42 })]
+async fn my_async_test_revert(
+    #[case] expected: u32,
+    #[await_future]
+    #[case]
+    value: u32,
+) {
+    assert_eq!(expected, value);
+}

--- a/rstest/tests/resources/rstest/matrix/await.rs
+++ b/rstest/tests/resources/rstest/matrix/await.rs
@@ -1,0 +1,11 @@
+use rstest::*;
+
+#[rstest]
+async fn my_async_test(
+    #[await_future]
+    #[values(async { 1 }, async { 2 })]
+    first: u32,
+    #[values(42, 21)] second: u32,
+) {
+    assert_eq!(42, first * second);
+}

--- a/rstest/tests/resources/rstest/single/await.rs
+++ b/rstest/tests/resources/rstest/single/await.rs
@@ -1,0 +1,28 @@
+use rstest::*;
+
+#[fixture]
+async fn fixture() -> u32 {
+    42
+}
+
+#[rstest]
+async fn should_pass(#[await_future] fixture: u32) {
+    assert_eq!(fixture, 42);
+}
+
+#[rstest]
+async fn should_fail(#[await_future] fixture: u32) {
+    assert_ne!(fixture, 42);
+}
+
+#[rstest]
+#[should_panic]
+async fn should_panic_pass(#[await_future] fixture: u32) {
+    panic!(format!("My panic -> fixture = {}", fixture));
+}
+
+#[rstest]
+#[should_panic]
+async fn should_panic_fail(#[await_future] fixture: u32) {
+    assert_eq!(fixture, 42);
+}

--- a/rstest/tests/rstest/mod.rs
+++ b/rstest/tests/rstest/mod.rs
@@ -326,9 +326,11 @@ mod single {
             .assert(output);
     }
 
-    #[test]
-    fn should_run_async_function() {
-        let prj = prj(res("async.rs"));
+    #[rstest]
+    #[case::future("async.rs")]
+    #[case::await_future("await.rs")]
+    fn should_run_async_function(#[case] file: &str) {
+        let prj = prj(res(file));
         prj.add_dependency("async-std", r#"{version="*", features=["attributes"]}"#);
 
         let output = prj.run_tests().unwrap();
@@ -456,9 +458,11 @@ mod cases {
             .assert(output);
     }
 
-    #[test]
-    fn should_run_async_function() {
-        let prj = prj(res("async.rs"));
+    #[rstest]
+    #[case::future("async.rs")]
+    #[case::await_future("await.rs")]
+    fn should_run_async_function(#[case] file: &str) {
+        let prj = prj(res(file));
         prj.add_dependency("async-std", r#"{version="*", features=["attributes"]}"#);
 
         let output = prj.run_tests().unwrap();
@@ -775,9 +779,11 @@ mod matrix {
             .assert(output);
     }
 
-    #[test]
-    fn should_run_async_function() {
-        let prj = prj(res("async.rs"));
+    #[rstest]
+    #[case::future("async.rs")]
+    #[case::await_future("await.rs")]
+    fn should_run_async_function(#[case] file: &str) {
+        let prj = prj(res(file));
         prj.add_dependency("async-std", r#"{version="*", features=["attributes"]}"#);
 
         let output = prj.run_tests().unwrap();

--- a/rstest_macros/src/error.rs
+++ b/rstest_macros/src/error.rs
@@ -105,10 +105,10 @@ macro_rules! merge_errors {
 }
 
 macro_rules! composed_tuple {
-    ($i:ident) => {
+    ($i:pat) => {
         $i
     };
-    ($i:ident, $($is:ident), +) => {
+    ($i:pat, $($is:pat), +) => {
         ($i, composed_tuple!($($is),*))
     };
 }

--- a/rstest_macros/src/lib.rs
+++ b/rstest_macros/src/lib.rs
@@ -476,7 +476,7 @@ pub fn fixture(
 ///
 /// ```
 /// use rstest::rstest;
-///  
+///
 /// fn sum(a: usize, b: usize) -> usize { a + b }
 ///
 /// #[rstest]
@@ -845,8 +845,7 @@ pub fn fixture(
 /// fn should_be_invalid_query_error(
 ///     repository: impl Repository,
 ///     #[case] user: User,
-///     #[values("     ", "^%$some#@invalid!chars", ".n.o.d.o.t.s.")] query: &str,
-///     query: &str
+///     #[values("     ", "^%$some#@invalid!chars", ".n.o.d.o.t.s.")] query: &str
 /// ) {
 ///     repository.find_items(&user, query).unwrap();
 /// }

--- a/rstest_macros/src/parse/mod.rs
+++ b/rstest_macros/src/parse/mod.rs
@@ -186,8 +186,12 @@ impl ToTokens for Fixture {
     }
 }
 
-pub(crate) fn extract_fixtures(item_fn: &mut ItemFn) -> Result<Vec<Fixture>, ErrorsVec> {
+pub(crate) fn extract_fixtures(
+    item_fn: &mut ItemFn,
+    current_items: &[Option<&Ident>],
+) -> Result<Vec<Fixture>, ErrorsVec> {
     let mut fixtures_extractor = FixturesFunctionExtractor::default();
+    fixtures_extractor.2 = current_items;
     fixtures_extractor.visit_item_fn_mut(item_fn);
 
     if fixtures_extractor.1.is_empty() {

--- a/rstest_macros/src/render/await_future.rs
+++ b/rstest_macros/src/render/await_future.rs
@@ -1,0 +1,86 @@
+use std::borrow::Cow;
+
+use quote::format_ident;
+use syn::{parse_quote, visit_mut::VisitMut, Expr, FnArg, Ident, Lifetime, Signature};
+
+use crate::{
+    parse::future::extend_generics_with_lifetimes, refident::MaybeIdent, resolver::Resolver,
+};
+
+#[derive(Default)]
+pub(crate) struct ReplaceAwaitAttribute<'a> {
+    await_args: &'a [Ident],
+    lifetimes: Vec<Lifetime>,
+}
+
+impl<'a> ReplaceAwaitAttribute<'a> {
+    pub(crate) fn replace(await_args: &[Ident], mut sig: Signature) -> Signature {
+        let mut visitor = Self::default();
+        visitor.await_args = await_args;
+        visitor.visit_signature_mut(&mut sig);
+        if !visitor.lifetimes.is_empty() {
+            sig.generics = extend_generics_with_lifetimes(
+                sig.generics.params.iter(),
+                visitor.lifetimes.iter(),
+            );
+        }
+        sig
+    }
+}
+
+impl<'a> VisitMut for ReplaceAwaitAttribute<'a> {
+    fn visit_fn_arg_mut(&mut self, node: &mut FnArg) {
+        let ident = if let Some(ident) = node.maybe_ident().cloned() {
+            ident
+        } else {
+            return;
+        };
+        match node {
+            FnArg::Typed(t) => {
+                if !self.await_args.contains(&ident) {
+                    return;
+                }
+                let ty = &mut t.ty;
+                use syn::Type::*;
+                if let Reference(tr) = ty.as_mut() {
+                    if tr.lifetime.is_none() {
+                        let lifetime = syn::Lifetime {
+                            apostrophe: ident.span(),
+                            ident: format_ident!("_{}", ident),
+                        };
+                        self.lifetimes.push(lifetime.clone());
+                        tr.lifetime = lifetime.into();
+                    }
+                }
+
+                t.ty = parse_quote! {
+                    impl std::future::Future<Output = #ty>
+                };
+            }
+            FnArg::Receiver(_) => {}
+        }
+    }
+}
+
+pub(crate) struct AwaitResolver<'a, SubResolver>
+where
+    SubResolver: Resolver,
+{
+    pub sub_resolver: SubResolver,
+    pub await_args: &'a [Ident],
+}
+
+impl<'a, SubResolver> Resolver for AwaitResolver<'a, SubResolver>
+where
+    SubResolver: Resolver,
+{
+    fn resolve(&self, ident: &Ident) -> Option<Cow<Expr>> {
+        self.sub_resolver.resolve(ident).map(|expr| {
+            if self.await_args.contains(ident) {
+                Cow::Owned(parse_quote! { #expr.await })
+            } else {
+                expr
+            }
+        })
+    }
+}

--- a/rstest_macros/src/render/fixture.rs
+++ b/rstest_macros/src/render/fixture.rs
@@ -79,7 +79,7 @@ pub(crate) fn render(fixture: ItemFn, info: FixtureInfo) -> TokenStream {
         impl #name {
             #(#orig_attrs)*
             #[allow(unused_mut)]
-            pub #asyncness fn get #generics (#orig_args) #output #where_clause {
+            #asyncness fn get #generics (#orig_args) #output #where_clause {
                 #call_impl
             }
 

--- a/rstest_macros/src/render/test.rs
+++ b/rstest_macros/src/render/test.rs
@@ -956,7 +956,7 @@ mod matrix_cases_should {
 
         let info = RsTestInfo {
             data: RsTestData {
-                items: vec![values_list("fix", &["1"]).into()].into(),
+                items: vec![values_list("_s", &["1"]).into()].into(),
             },
             ..Default::default()
         };

--- a/rstest_macros/src/render/test.rs
+++ b/rstest_macros/src/render/test.rs
@@ -1233,7 +1233,14 @@ mod matrix_cases_should {
         attributes.add_notraces(vec![ident("b_no_trace_me"), ident("c_no_trace_me")]);
         let item_fn: ItemFn = r#"#[trace] fn test(a_trace_me: u32, b_no_trace_me: u32, c_no_trace_me: u32, d_trace_me: u32) {}"#.ast();
 
-        let tokens = matrix(item_fn, RsTestInfo { data, attributes });
+        let tokens = matrix(
+            item_fn,
+            RsTestInfo {
+                data,
+                attributes,
+                await_args: vec![],
+            },
+        );
 
         let tests = TestsGroup::from(tokens).get_all_tests();
 

--- a/rstest_macros/src/test.rs
+++ b/rstest_macros/src/test.rs
@@ -123,7 +123,7 @@ pub(crate) fn expr(s: impl AsRef<str>) -> syn::Expr {
 pub(crate) fn attrs(s: impl AsRef<str>) -> Vec<syn::Attribute> {
     parse_str::<ItemFn>(&format!(
         r#"{}
-           fn _no_name_() {{}}   
+           fn _no_name_() {{}}
         "#,
         s.as_ref()
     ))
@@ -258,6 +258,7 @@ impl From<RsTestData> for RsTestInfo {
         Self {
             data,
             attributes: Default::default(),
+            await_args: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Async fixture are kind of hard to use currently as reported in #157 . This PR adds a syntax to make tests with async fixtures easier to write.

Before:

```rust
    #[rstest]
    async fn it_can_return_its_ip(#[future] client: Client) {
        let client = client.await;
        client.doThis();
        client.doThat();
    }
```

After:

```rust
    #[rstest]
    async fn it_can_return_its_ip(#[await_future] client: Client) {
        client.doThis();
        client.doThat();
    }
```

This PR is ready code-wise, but it still lacks some tests and documentation. I wanted to get feedback for this approach before going further, please tell me what you think :)