### PR TITLE
Add licenses

### DIFF
--- a/playground/LICENCE-MIT
+++ b/playground/LICENCE-MIT
@@ -1,0 +1,1 @@
+../LICENCE-MIT

--- a/playground/LICENSE-APACHE
+++ b/playground/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rstest/LICENCE-MIT
+++ b/rstest/LICENCE-MIT
@@ -1,0 +1,1 @@
+../LICENCE-MIT

--- a/rstest/LICENSE-APACHE
+++ b/rstest/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rstest_fixtures/LICENCE-MIT
+++ b/rstest_fixtures/LICENCE-MIT
@@ -1,0 +1,1 @@
+../LICENCE-MIT

--- a/rstest_fixtures/LICENSE-APACHE
+++ b/rstest_fixtures/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rstest_macros/LICENCE-MIT
+++ b/rstest_macros/LICENCE-MIT
@@ -1,0 +1,1 @@
+../LICENCE-MIT

--- a/rstest_macros/LICENSE-APACHE
+++ b/rstest_macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rstest_reuse/LICENCE-MIT
+++ b/rstest_reuse/LICENCE-MIT
@@ -1,0 +1,1 @@
+../LICENCE-MIT

--- a/rstest_reuse/LICENSE-APACHE
+++ b/rstest_reuse/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rstest_test/LICENCE-MIT
+++ b/rstest_test/LICENCE-MIT
@@ -1,0 +1,1 @@
+../LICENCE-MIT

--- a/rstest_test/LICENSE-APACHE
+++ b/rstest_test/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE


### PR DESCRIPTION
Symlink license files from the parent directory so that crates are created with them.

Needed for distribution especially for the MIT license.