### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/rstest/Cargo.toml
+++ b/rstest/Cargo.toml
@@ -8,7 +8,7 @@ to implement fixtures and table based tests.
 edition = "2021"
 homepage = "https://github.com/la10736/rstest"
 keywords = ["test", "fixture"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 name = "rstest"
 readme = "README.md"
 repository = "https://github.com/la10736/rstest"

--- a/rstest_macros/Cargo.toml
+++ b/rstest_macros/Cargo.toml
@@ -8,7 +8,7 @@ to implement fixtures and table based tests.
 edition = "2021"
 homepage = "https://github.com/la10736/rstest"
 keywords = ["test", "fixture"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 name = "rstest_macros"
 repository = "https://github.com/la10736/rstest"
 version = "0.19.0"

--- a/rstest_reuse/Cargo.toml
+++ b/rstest_reuse/Cargo.toml
@@ -8,7 +8,7 @@ to every scenario you want to test.
 edition = "2021"
 homepage = "https://github.com/la10736/rstest"
 keywords = ["test", "fixture"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 name = "rstest_reuse"
 readme = "README.md"
 repository = "https://github.com/la10736/rstest"

--- a/rstest_test/Cargo.toml
+++ b/rstest_test/Cargo.toml
@@ -7,7 +7,7 @@ Provides some utilities used by to write rstest crate's tests.
 edition = "2021"
 homepage = "https://github.com/la10736/rstest"
 keywords = ["test"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 name = "rstest_test"
 readme = "README.md"
 repository = "https://github.com/la10736/rstest"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields