### PR TITLE
readme: make all links relative to the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,20 +461,20 @@ is raised, but it's also possible to exclude a variable using the
 `#[notrace]` argument attribute.
 
 You can learn more on [Docs][docs-link] and find more examples in
-[`tests/resources`](tests/resources) directory.
+[`tests/resources`](/rstest/tests/resources) directory.
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md)
+See [CHANGELOG.md](/CHANGELOG.md)
 
 ## License
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+* Apache License, Version 2.0, ([LICENSE-APACHE](/LICENSE-APACHE) or
 [license-apache-link])
 
-* MIT license [LICENSE-MIT](LICENSE-MIT) or [license-MIT-link]
+* MIT license [LICENSE-MIT](/LICENSE-MIT) or [license-MIT-link]
 at your option.
 
 [//]: # (links)


### PR DESCRIPTION
The link to the tests folder breaks when
accessed from the root folder.
Other links break in the linked version
in the rstest folder.
To make all them work, make them relative
to the repository root.