### PR TITLE
Properly handle mutability for awaited futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Add
 
+- `#[future(awt)]` and `#[awt]` now properly handle mutable (`mut`) parameters by treating futures as immutable and
+  treating the awaited rebinding as mutable.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 ### Add
 
-- `#[future(awt)]` and `#[awt]` now properly handle mutable (`mut`) parameters by treating futures as immutable and
-  treating the awaited rebinding as mutable.
-
 ### Changed
 
 ### Fixed
@@ -15,6 +12,8 @@
 [`Sync`](https://doc.rust-lang.org/std/marker/trait.Sync.html) to prevent UB
 when tests are executed in parallel. (see [#235](https://github.com/la10736/rstest/issues/235)
 for more details)
+- `#[future(awt)]` and `#[awt]` now properly handle mutable (`mut`) parameters by treating futures as immutable and
+  treating the awaited rebinding as mutable.
 
 ## [0.18.2] 2023/8/13
 

--- a/rstest/tests/resources/rstest/cases/async_awt_mut.rs
+++ b/rstest/tests/resources/rstest/cases/async_awt_mut.rs
@@ -1,0 +1,24 @@
+use rstest::*;
+
+#[rstest]
+#[case::pass(async { 3 })]
+#[awt]
+async fn my_mut_test_global_awt(
+    #[future]
+    #[case]
+    mut a: i32,
+) {
+    a = 4;
+    assert_eq!(a, 4);
+}
+
+#[rstest]
+#[case::pass(async { 3 })]
+async fn my_mut_test_local_awt(
+    #[future(awt)]
+    #[case]
+    mut a: i32,
+) {
+    a = 4;
+    assert_eq!(a, 4);
+}

--- a/rstest/tests/rstest/mod.rs
+++ b/rstest/tests/rstest/mod.rs
@@ -534,6 +534,19 @@ mod cases {
             .assert(output);
     }
 
+    #[rstest]
+    fn should_run_async_mut() {
+        let prj = prj(res("async_awt_mut.rs"));
+        prj.add_dependency("async-std", r#"{version="*", features=["attributes"]}"#);
+
+        let output = prj.run_tests().unwrap();
+
+        TestResults::new()
+            .ok("my_mut_test_global_awt::case_1_pass")
+            .ok("my_mut_test_local_awt::case_1_pass")
+            .assert(output);
+    }
+
     #[test]
     fn should_use_injected_test_attr() {
         let prj = prj(res("inject.rs"));

--- a/rstest_macros/src/refident.rs
+++ b/rstest_macros/src/refident.rs
@@ -1,7 +1,7 @@
 /// Provide `RefIdent` and `MaybeIdent` traits that give a shortcut to extract identity reference
 /// (`syn::Ident` struct).
 use proc_macro2::Ident;
-use syn::{FnArg, Pat, PatType, Token, Type};
+use syn::{FnArg, Pat, PatType, Type};
 
 pub trait RefIdent {
     /// Return the reference to ident if any
@@ -87,15 +87,15 @@ impl MaybeIdent for crate::parse::Attribute {
     }
 }
 
-pub trait MaybeMutability {
-    fn maybe_mutability(&self) -> Option<Token![mut]>;
+pub trait MaybePatIdent {
+    fn maybe_patident(&self) -> Option<&syn::PatIdent>;
 }
 
-impl MaybeMutability for FnArg {
-    fn maybe_mutability(&self) -> Option<Token![mut]> {
+impl MaybePatIdent for FnArg {
+    fn maybe_patident(&self) -> Option<&syn::PatIdent> {
         match self {
             FnArg::Typed(PatType { pat, .. }) => match pat.as_ref() {
-                Pat::Ident(ident) => ident.mutability,
+                Pat::Ident(ident) => Some(ident),
                 _ => None,
             },
             _ => None,
@@ -104,11 +104,11 @@ impl MaybeMutability for FnArg {
 }
 
 pub trait SetMutability {
-    fn set_mutability(&mut self, mutability: Option<Token![mut]>);
+    fn set_mutability(&mut self, mutability: Option<syn::token::Mut>);
 }
 
 impl SetMutability for FnArg {
-    fn set_mutability(&mut self, mutability: Option<Token![mut]>) {
+    fn set_mutability(&mut self, mutability: Option<syn::token::Mut>) {
         match self {
             FnArg::Typed(PatType { pat, .. }) => match pat.as_mut() {
                 Pat::Ident(ident) => ident.mutability = mutability,

--- a/rstest_macros/src/refident.rs
+++ b/rstest_macros/src/refident.rs
@@ -103,15 +103,15 @@ impl MaybePatIdent for FnArg {
     }
 }
 
-pub trait SetMutability {
-    fn set_mutability(&mut self, mutability: Option<syn::token::Mut>);
+pub trait RemoveMutability {
+    fn remove_mutability(&mut self);
 }
 
-impl SetMutability for FnArg {
-    fn set_mutability(&mut self, mutability: Option<syn::token::Mut>) {
+impl RemoveMutability for FnArg {
+    fn remove_mutability(&mut self) {
         match self {
             FnArg::Typed(PatType { pat, .. }) => match pat.as_mut() {
-                Pat::Ident(ident) => ident.mutability = mutability,
+                Pat::Ident(ident) => ident.mutability = None,
                 _ => {}
             },
             _ => {}

--- a/rstest_macros/src/refident.rs
+++ b/rstest_macros/src/refident.rs
@@ -1,7 +1,7 @@
 /// Provide `RefIdent` and `MaybeIdent` traits that give a shortcut to extract identity reference
 /// (`syn::Ident` struct).
 use proc_macro2::Ident;
-use syn::{FnArg, Pat, PatType, Type};
+use syn::{FnArg, Pat, PatType, Token, Type};
 
 pub trait RefIdent {
     /// Return the reference to ident if any
@@ -84,5 +84,37 @@ impl MaybeIdent for crate::parse::Attribute {
         match self {
             Attr(ident) | Tagged(ident, _) | Type(ident, _) => Some(ident),
         }
+    }
+}
+
+pub trait MaybeMutability {
+    fn maybe_mutability(&self) -> Option<Token![mut]>;
+}
+
+impl MaybeMutability for FnArg {
+    fn maybe_mutability(&self) -> Option<Token![mut]> {
+        match self {
+            FnArg::Typed(PatType { pat, .. }) => match pat.as_ref() {
+                Pat::Ident(ident) => ident.mutability,
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+pub trait SetMutability {
+    fn set_mutability(&mut self, mutability: Option<Token![mut]>);
+}
+
+impl SetMutability for FnArg {
+    fn set_mutability(&mut self, mutability: Option<Token![mut]>) {
+        match self {
+            FnArg::Typed(PatType { pat, .. }) => match pat.as_mut() {
+                Pat::Ident(ident) => ident.mutability = mutability,
+                _ => {}
+            },
+            _ => {}
+        };
     }
 }

--- a/rstest_macros/src/render/apply_argumets.rs
+++ b/rstest_macros/src/render/apply_argumets.rs
@@ -3,7 +3,7 @@ use syn::{parse_quote, FnArg, Generics, Ident, ItemFn, Lifetime, Signature, Type
 
 use crate::{
     parse::{arguments::ArgumentsInfo, future::MaybeFutureImplType},
-    refident::{MaybeIdent, MaybeMutability, SetMutability},
+    refident::{MaybeIdent, MaybePatIdent, SetMutability},
 };
 
 pub(crate) trait ApplyArgumets<R: Sized = ()> {
@@ -59,17 +59,20 @@ impl ApplyArgumets for Signature {
 
 impl ApplyArgumets for ItemFn {
     fn apply_argumets(&mut self, arguments: &ArgumentsInfo) {
-        let awaited_args = self
+        let rebound_awaited_args = self
             .sig
             .inputs
             .iter()
-            .filter_map(|a| a.maybe_ident().map(|i| (i, a.maybe_mutability())))
-            .filter(|(a, _)| arguments.is_future_await(a))
-            .map(|(a, m)| quote::quote! { let #m #a = #a.await; });
+            .filter_map(|a| a.maybe_patident())
+            .filter(|p| arguments.is_future_await(&p.ident))
+            .map(|p| {
+                let a = &p.ident;
+                quote::quote! { let #p = #a.await; }
+            });
         let orig_block_impl = self.block.clone();
         self.block = parse_quote! {
             {
-                #(#awaited_args)*
+                #(#rebound_awaited_args)*
                 #orig_block_impl
             }
         };
@@ -154,6 +157,11 @@ mod should {
         "fn f<S: AsRef<str>>(a: S) {}",
         &["a"],
         "fn f<S: AsRef<str>>(a: impl std::future::Future<Output = S>) {}"
+    )]
+    #[case::remove_mut(
+        "fn f(a: u32) {}",
+        &["a"],
+        r#"fn f(a: impl std::future::Future<Output = u32>) {}"#
     )]
     fn replace_future_basic_type(
         #[case] item_fn: &str,
@@ -245,6 +253,18 @@ mod should {
             assert_not_in!(code, await_argument_code_string("a"));
             assert_in!(code, await_argument_code_string("b"));
             assert_not_in!(code, await_argument_code_string("c"));
+        }
+
+        #[test]
+        fn with_mut_await() {
+            let mut item_fn: ItemFn = r#"fn test(mut a: i32) {} "#.ast();
+            let mut arguments: ArgumentsInfo = Default::default();
+            arguments.set_future(ident("a"), FutureArg::Await);
+
+            item_fn.apply_argumets(&arguments);
+
+            let code = item_fn.block.display_code();
+            assert_in!(code, mut_await_argument_code_string("a"));
         }
     }
 }

--- a/rstest_macros/src/render/apply_argumets.rs
+++ b/rstest_macros/src/render/apply_argumets.rs
@@ -3,7 +3,7 @@ use syn::{parse_quote, FnArg, Generics, Ident, ItemFn, Lifetime, Signature, Type
 
 use crate::{
     parse::{arguments::ArgumentsInfo, future::MaybeFutureImplType},
-    refident::{MaybeIdent, MaybePatIdent, SetMutability},
+    refident::{MaybeIdent, MaybePatIdent, RemoveMutability},
 };
 
 pub(crate) trait ApplyArgumets<R: Sized = ()> {
@@ -93,7 +93,7 @@ impl ImplFutureArg for FnArg {
                 *ty = parse_quote! {
                     impl std::future::Future<Output = #ty>
                 };
-                self.set_mutability(None);
+                self.remove_mutability();
                 lifetime
             }
             None => None,
@@ -159,7 +159,7 @@ mod should {
         "fn f<S: AsRef<str>>(a: impl std::future::Future<Output = S>) {}"
     )]
     #[case::remove_mut(
-        "fn f(a: u32) {}",
+        "fn f(mut a: u32) {}",
         &["a"],
         r#"fn f(a: impl std::future::Future<Output = u32>) {}"#
     )]

--- a/rstest_macros/src/test.rs
+++ b/rstest_macros/src/test.rs
@@ -319,3 +319,11 @@ pub(crate) fn await_argument_code_string(arg_name: &str) -> String {
     };
     statment.display_code()
 }
+
+pub(crate) fn mut_await_argument_code_string(arg_name: &str) -> String {
+    let arg_name = ident(arg_name);
+    let statement: Stmt = parse_quote! {
+        let mut #arg_name = #arg_name.await;
+    };
+    statement.display_code()
+}


### PR DESCRIPTION
# Motivation

Currently, the following code fails to compile:

```rust
#[rstest]
#[case(async { 3 })]
async fn my_test(
    #[case]
    #[future(awt)]
    mut a: u8,
) {
    a = 4;
    assert_eq!(a, 4);
}
```

as (the inner function) expands to

```rust
async fn my_test(mut a: impl std::future::Future<Output = u8>) {
    let a = a.await;
    {
        a = 4;  // <-- this is an issue, `a` is not mutable, but the future is!
        assert_eq!(a, 4);
    }
}
```

This is most likely undesired: by marking the awaited future value as `mut`, one would expect that `a` is mutable.

# Changes

This PR augments the mutability identifier to result in the following expanded code that now compiles as expected:

```rust
async fn my_test(a: impl std::future::Future<Output = u8>) {  // <-- no `mut` for the future anymore -- await NEVER requires `mut`
    let mut a = a.await;  // <-- this is now correctly marked mutable
    {
        a = 4;
        assert_eq!(a, 4);
    }
}
```