### PR TITLE
Fix typo that prevented running the tests on beta and nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,11 @@ jobs:
     - name: Build
       run: cargo build --all --verbose
     - name: Run tests stable
-      run: RSTEST_TEST_CHANNEL=stable; cargo test --all --verbose
+      run: RSTEST_TEST_CHANNEL=stable cargo test --all --verbose
     - name: Run tests beta
-      run: RSTEST_TEST_CHANNEL=beta; cargo test --all --verbose
+      run: RSTEST_TEST_CHANNEL=beta cargo test --all --verbose
     - name: Run tests nightly
-      run: RSTEST_TEST_CHANNEL=nightly; cargo test --all --verbose
+      run: RSTEST_TEST_CHANNEL=nightly cargo test --all --verbose
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
       with:
           toolchain: nightly
           override: true
+    - name: Install latest beta
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: beta
     - name: Build
       run: cargo build --all --verbose
     - name: Run tests stable


### PR DESCRIPTION
Environment variables are not visible in child processes unless they are set in the same command (or using `export`):

```bash
$ cat test.sh
#!/usr/bin/env bash

echo $SOME_ENV_VAR
$ SOME_ENV_VAR=hello ./test.sh
hello
$ SOME_ENV_VAR=hello; ./test.sh

$
```