### PR TITLE
Fully qualify `PathBuf` in `#[files]` expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Don't remove Lifetimes from test function if any. See [#230](https://github.com/la10736/rstest/issues/230)
 [#241](https://github.com/la10736/rstest/issues/241) for more details.
+- [`PathBuf`](https://doc.rust-lang.org/std/path/struct.PathBuf.html) does no longer need to be
+in scope when using `#[files]` (see [#242](https://github.com/la10736/rstest/pull/242))
 
 ## [0.19.0] 2024/4/9
 

--- a/rstest/tests/resources/rstest/files.rs
+++ b/rstest/tests/resources/rstest/files.rs
@@ -32,3 +32,14 @@ fn start_with_name_with_include(
 
     assert!(contents.starts_with(name.to_str().unwrap()))
 }
+
+mod module {
+    #[rstest::rstest]
+    fn pathbuf_need_not_be_in_scope(
+        #[files("files/**/*.txt")]
+        #[exclude("exclude")]
+        #[include_dot_files]
+        path: std::path::PathBuf,
+    ) {
+    }
+}

--- a/rstest/tests/rstest/mod.rs
+++ b/rstest/tests/rstest/mod.rs
@@ -74,6 +74,12 @@ fn files() {
         .ok("start_with_name_with_include::path_4_files_element_2_txt")
         .ok("start_with_name_with_include::path_5_files_element_3_txt")
         .ok("start_with_name_with_include::path_6_files_sub_sub_dir_file_txt")
+        .ok("module::pathbuf_need_not_be_in_scope::path_1_files__ignore_me_txt")
+        .ok("module::pathbuf_need_not_be_in_scope::path_2_files_element_0_txt")
+        .ok("module::pathbuf_need_not_be_in_scope::path_3_files_element_1_txt")
+        .ok("module::pathbuf_need_not_be_in_scope::path_4_files_element_2_txt")
+        .ok("module::pathbuf_need_not_be_in_scope::path_5_files_element_3_txt")
+        .ok("module::pathbuf_need_not_be_in_scope::path_6_files_sub_sub_dir_file_txt")
         .assert(output);
 }
 

--- a/rstest_macros/src/parse/rstest/files.rs
+++ b/rstest_macros/src/parse/rstest/files.rs
@@ -331,7 +331,7 @@ impl<'a> ValueListFromFiles<'a> {
             let path_str = abs_path.to_string_lossy();
             values.push((
                 parse_quote! {
-                    <PathBuf as std::str::FromStr>::from_str(#path_str).unwrap()
+                    <::std::path::PathBuf as std::str::FromStr>::from_str(#path_str).unwrap()
                 },
                 render_file_description(&relative_path),
             ));
@@ -642,7 +642,7 @@ mod should {
                 .map(|r| r.to_logical_path(bdir))
                 .map(|p| {
                     format!(
-                        r#"<PathBuf as std::str::FromStr>::from_str("{}").unwrap()"#,
+                        r#"<::std::path::PathBuf as std::str::FromStr>::from_str("{}").unwrap()"#,
                         p.as_os_str().to_str().unwrap()
                     )
                 })


### PR DESCRIPTION
Otherwise `PathBuf` would have to be in scope where `#[files]` is used.