### PR TITLE
Dont_remove_lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@
 
 ### Fixed
 
+- Don't remove Lifetimes from test function if any. See [#230](https://github.com/la10736/rstest/issues/230)
+[#241](https://github.com/la10736/rstest/issues/241) for more details.
+
 ## [0.19.0] 2024/4/9
 
 ### Changed
 
-- Defined `rust-version` for each crate (see [#227](https://github.com/la10736/rstest/issues/235))
+- Defined `rust-version` for each crate (see [#227](https://github.com/la10736/rstest/issues/227))
 
 ### Fixed
 

--- a/rstest/tests/resources/rstest/lifetimes.rs
+++ b/rstest/tests/resources/rstest/lifetimes.rs
@@ -1,0 +1,21 @@
+use rstest::*;
+
+enum E<'a> {
+    A(bool),
+    B(&'a std::cell::Cell<E<'a>>),
+}
+
+#[rstest]
+#[case(E::A(true))]
+fn case<'a>(#[case] e: E<'a>) {}
+
+#[rstest]
+fn values<'a>(#[values(E::A(true))] e: E<'a>) {}
+
+#[fixture]
+fn e<'a>() -> E<'a> {
+    E::A(true)
+}
+
+#[rstest]
+fn fixture<'a>(e: E<'a>) {}

--- a/rstest/tests/rstest/mod.rs
+++ b/rstest/tests/rstest/mod.rs
@@ -169,6 +169,18 @@ fn use_mutable_fixture_in_parametric_argumnts() {
 }
 
 #[test]
+fn should_not_remove_lifetimes() {
+    let (output, _) = run_test("lifetimes.rs");
+
+    TestResults::new()
+        .with_contains(true)
+        .ok("case")
+        .ok("values")
+        .ok("fixture")
+        .assert(output);
+}
+
+#[test]
 fn should_reject_no_item_function() {
     let (output, name) = run_test("reject_no_item_function.rs");
 

--- a/rstest_macros/src/render/test.rs
+++ b/rstest_macros/src/render/test.rs
@@ -80,6 +80,20 @@ mod single_test_should {
         assert_eq!(inner_fn_impl.display_code(), input_fn.block.display_code());
     }
 
+    #[test]
+    fn not_remove_lifetimes() {
+        let input_fn: ItemFn = r#"
+                pub fn test<'a, 'b, 'c: 'a + 'b>(a: A<'a>, b: A<'b>, c: A<'c>) -> A<'c>
+                {
+                }
+                "#
+        .ast();
+
+        let result: ItemFn = single(input_fn.clone(), Default::default()).ast();
+
+        assert_eq!(3, result.sig.generics.lifetimes().count());
+    }
+
     #[rstest]
     fn not_copy_any_attributes(
         #[values(


### PR DESCRIPTION
Tests function can have lifetimes that can be used in the code: we cannot remove them if any.