### PR TITLE
No longer require `rstest_reuse` to be imported explicitly into the crate root

### DIFF
--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -360,7 +360,7 @@ pub fn template(_args: proc_macro::TokenStream, input: proc_macro::TokenStream) 
         #macro_attribute
         macro_rules! #macro_name_rand {
             ( $test:item ) => {
-                        $crate::rstest_reuse::merge_attrs! {
+                        ::rstest_reuse::merge_attrs! {
                             #template,
                             $test
                         }

--- a/rstest_reuse/tests/acceptance.rs
+++ b/rstest_reuse/tests/acceptance.rs
@@ -183,6 +183,15 @@ fn should_export_main_root() {
     TestResults::new().ok("test::case_1").assert(output);
 }
 
+#[test]
+fn rstest_reuse_not_in_crate_root() {
+    let (output, _) = run_test("rstest_reuse_not_in_crate_root.rs");
+
+    TestResults::new()
+        .ok("test::case_1")
+        .assert(output);
+}
+
 lazy_static! {
     static ref ROOT_DIR: TempDir = TempDir::new(std::env::temp_dir().join("rstest_reuse"), false);
     static ref ROOT_PROJECT: Project = Project::new(ROOT_DIR.as_ref());

--- a/rstest_reuse/tests/resources/rstest_reuse_not_in_crate_root.rs
+++ b/rstest_reuse/tests/resources/rstest_reuse_not_in_crate_root.rs
@@ -1,0 +1,13 @@
+use rstest::rstest;
+use rstest_reuse::apply;
+use rstest_reuse::template;
+
+#[template]
+#[rstest]
+#[case(42)]
+fn test_template(#[case] n: u32) {}
+
+#[apply(test_template)]
+fn test(#[case] n: u32) {
+    assert_eq!(n, 42);
+}

--- a/rstest_reuse/tests/resources/simple_example.rs
+++ b/rstest_reuse/tests/resources/simple_example.rs
@@ -1,5 +1,5 @@
 use rstest::rstest;
-use rstest_reuse::{self, *};
+use rstest_reuse::*;
 
 #[template]
 #[rstest(a,  b, case(2, 2), case(4/2, 2))]


### PR DESCRIPTION
I think using `$crate` is not correct here: It requires an otherwise unneeded `use rstest_reuse;` in the crate root. Using [a leading `::`](https://doc.rust-lang.org/reference/paths.html#path-qualifiers) guarantees that `::rstest_reuse` is resolved to the `rstest_reuse` crate and not some name declared in the current crate.