### PR TITLE
Allow environment variables in #[files] attributes

### DIFF
--- a/rstest/tests/resources/rstest/files.rs
+++ b/rstest/tests/resources/rstest/files.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 #[rstest]
 fn start_with_name(
-    #[files("files/**/*.txt")]
+    #[files("${HELLO_WORLD}files/**/*.txt")]
     #[exclude("exclude")]
     #[files("../files_test_sub_folder/**/*.txt")]
     path: PathBuf,


### PR DESCRIPTION
The environment variable must be passed to cargo test. Any variable name is valid and would be replaced. If a variable is not defined, the macro will error with the proper error message.

Fixes #276