### PR TITLE
Append generated test macro so next test macros are aware of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Append generated test macro so next test macros are aware of it (see [#291](https://github.com/la10736/rstest/pull/291)).
+
 ### Add
 
 ### Fix

--- a/rstest_macros/src/render/mod.rs
+++ b/rstest_macros/src/render/mod.rs
@@ -374,8 +374,8 @@ fn single_test_case(
     let lifetimes = generics.lifetimes();
 
     quote! {
-        #test_attr
         #(#attrs)*
+        #test_attr
         #asyncness fn #name<#(#lifetimes,)*>(#(#ignored_args,)*) #output {
             #test_impl
             #inject


### PR DESCRIPTION
This way test macros following `#[rstest]` can decide whether or not to generate test macro to avoid duplicate test runs.

It is an attempt to improve capabilities among test macros. Currently, following test from [googletest](https://github.com/google/googletest-rust/blob/21f2948684847922a416252b8118e3eada8e29d6/integration_tests/src/google_test_with_rstest.rs#L52-L57)(`main` branch at 2025-01-16) will run twice.

```rust
#[rstest]
#[case(1)]
#[gtest]
fn paramterised_test_should_work_with_rstest_first(#[case] value: u32) -> Result<()> {
    verify_that!(value, eq(value))
}
```

See: tokio-rs/tokio#6497, d-e-s-o/test-log#46, frondeus/test-case#143, kezhuw/stuck#53.
Refs: rust-lang/rust#67839, rust-lang/rust#82419.