### PR TITLE
docs: fix filemode examples

### DIFF
--- a/rstest/src/lib.rs
+++ b/rstest/src/lib.rs
@@ -1047,10 +1047,13 @@ pub use rstest_macros::fixture;
 ///
 /// ```
 /// # use rstest::rstest;
+/// # use std::path::PathBuf;
+/// # use std::fs::read_to_string;
 /// #[rstest]
 /// fn for_each_path(
 ///     #[files("src/**/*.rs")] #[exclude("test")] #[mode = path] path: PathBuf
 /// ) {
+///     let contents = read_to_string(path).unwrap();
 ///     assert!(contents.len() >= 0)
 /// }
 ///


### PR DESCRIPTION
Fixes the doc examples for file modes introduced in #297.
See [this comment](https://github.com/la10736/rstest/pull/297#discussion_r1986081633) for more info.