### PR TITLE
Make the `template` proc macro inner name consistent

### DIFF
--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -331,12 +331,12 @@ pub fn template(_args: proc_macro::TokenStream, input: proc_macro::TokenStream) 
     };
 
     let macro_name = template.sig.ident.clone();
-    let macro_name_rand = format_ident!("{}_{}", macro_name, rand::random::<u64>());
+    let macro_inner_name = format_ident!("{}_inner", macro_name);
 
     let tokens = quote! {
         /// Apply #macro_name template to given body
         #macro_attribute
-        macro_rules! #macro_name_rand {
+        macro_rules! #macro_inner_name {
             ( $test:item ) => {
                         ::rstest_reuse::merge_attrs! {
                             #template,
@@ -345,7 +345,7 @@ pub fn template(_args: proc_macro::TokenStream, input: proc_macro::TokenStream) 
                     }
         }
         #[allow(unused_imports)]
-        #visibility use #macro_name_rand as #macro_name;
+        #visibility use #macro_inner_name as #macro_name;
     };
     tokens.into()
 }


### PR DESCRIPTION
Because the inner name of the macro changes, tools that detect semver-related changes like [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) think its a new macro every time, making them mark it as a major breaking change.
More specifically, you can see `cargo-semver-checks` marking it as a breaking change in two of our releases that didn't make any related change to it - [0.27](https://github.com/spiraldb/vortex/pull/2888) and [0.28](https://github.com/spiraldb/vortex/pull/2897) (its the first change in both releases).

The change here is just making the internal name consistent, with a fixed suffix instead of a random number. Tested it both with the repo's test suite and on our own usage.

Also wanted to say thank you for `rstest`! Been using it for over 3 years now across two companies and its always been super useful, covering basically every usecase I had.