### PR TITLE
Fix Windows handling for #[files] (fixes #287)

### DIFF
--- a/rstest_test/src/prj.rs
+++ b/rstest_test/src/prj.rs
@@ -192,7 +192,7 @@ impl Project {
     }
 
     pub fn add_path_dependency(&self, name: &str, path: &str) {
-        self.add_dependency(name, format!(r#"{{path="{path}"}}"#).as_str());
+        self.add_dependency(name, format!(r#"{{path={path:?}}}"#).as_str());
     }
 
     pub fn add_local_dependency(&self, name: &str) {


### PR DESCRIPTION
Hi this is the PR with the basic backslash bodge. The tests just aren't going to pass in Windows without some massive work so I wasn't confident replacing relative-path. So I ran just the tests relevant to the files macro and it seems to work by 1. using absolute instead of canonicalize on Windows 2. replacing backslashes with slashes. It's a bit of a hack I guess but it works, yay? 

The tests for that module and the integration tests for it pass except for the glob tests which again hardcode forward slashes so it doesn't match windows's backslash paths.

I tested it with a personal project and it works too.