### PR TITLE
Issue #306. Ignore folders

### DIFF
--- a/rstest/tests/resources/rstest/files.rs
+++ b/rstest/tests/resources/rstest/files.rs
@@ -50,6 +50,22 @@ fn start_with_name_with_include(
 }
 
 #[rstest]
+fn ignore_directories_wildcard(
+    #[files("folders/**/*")]
+    path: PathBuf,
+) {
+    assert!(!path.is_dir())
+}
+
+#[rstest]
+fn ignore_directories(
+    #[files("folders/**/*.txt")]
+    path: PathBuf,
+) {
+    assert!(!path.is_dir())
+}
+
+#[rstest]
 fn ignore_missing_env_vars(
     #[ignore_missing_env_vars]
     #[files("files/**/${__SHOULD_NOT_BE_DECLARED__}*.txt")]

--- a/rstest/tests/rstest/mod.rs
+++ b/rstest/tests/rstest/mod.rs
@@ -1,5 +1,4 @@
 use std::{fs::File, io::Write, path::Path};
-
 use mytest::*;
 use rstest_test::*;
 use unindent::Unindent;
@@ -21,6 +20,20 @@ fn run_test(res: impl AsRef<Path>) -> (std::process::Output, String) {
     )
 }
 
+fn prepare_folders_tests(project_path: std::path::PathBuf) {
+    let folders_path = project_path.join("folders");
+
+    let folder_with_txt_extension_path = folders_path.join("folder_but.txt");
+    let sub_folder_path = folders_path.join("sub");
+
+    std::fs::create_dir(&folders_path).unwrap();
+    std::fs::create_dir(&folder_with_txt_extension_path).unwrap();
+    std::fs::create_dir(&sub_folder_path).unwrap();
+
+    let text_file_path = sub_folder_path.join("file.txt");
+    File::create(text_file_path).unwrap();
+}
+
 #[test]
 fn files() {
     std::env::set_var("FILES_ENV_VAR", "files");
@@ -32,6 +45,8 @@ fn files() {
     std::fs::create_dir(&files_path).unwrap();
     std::fs::create_dir(&sub_folder).unwrap();
     std::fs::create_dir(&up_sub_folder).unwrap();
+
+    prepare_folders_tests(prj.path());
 
     for n in 0..4 {
         let name = format!("element_{}.txt", n);
@@ -120,6 +135,8 @@ fn files() {
         .ok("start_with_name_with_include::path_4_files_element_2_txt")
         .ok("start_with_name_with_include::path_5_files_element_3_txt")
         .ok("start_with_name_with_include::path_6_files_sub_sub_dir_file_txt")
+        .ok("ignore_directories::path_1_folders_sub_file_txt")
+        .ok("ignore_directories_wildcard::path_1_folders_sub_file_txt")
         .assert(output);
 }
 

--- a/rstest_macros/src/parse/rstest/files.rs
+++ b/rstest_macros/src/parse/rstest/files.rs
@@ -583,7 +583,7 @@ impl ValueListFromFiles<'_> {
                     attr.error(&format!("Invalid absolute path {}", e.to_string_lossy()))
                 })?;
 
-            if !refs.is_valid(&relative_path) {
+            if abs_path.is_dir() || !refs.is_valid(&relative_path) {
                 continue;
             }
 


### PR DESCRIPTION
We could ignore the directories in the place where we the check the dot files to be included. I've added two integration tests with both possible cases where the directory is returned.