### PR TITLE
Hide generated items in documentation

### DIFF
--- a/rstest/tests/fixture/mod.rs
+++ b/rstest/tests/fixture/mod.rs
@@ -379,6 +379,15 @@ mod should {
         }
 
         #[rstest]
+        fn deny_docs() {
+            let (output, _) = run_test("deny_docs.rs");
+
+            assert_not_in!(output.stdout.str(), "missing_docs");
+
+            TestResults::new().ok("success").fail("fail").assert(output);
+        }
+
+        #[rstest]
         fn once_async(errors_once_rs: &(Output, String)) {
             let (output, name) = errors_once_rs.clone();
             assert_in!(

--- a/rstest/tests/resources/fixture/deny_docs.rs
+++ b/rstest/tests/resources/fixture/deny_docs.rs
@@ -1,0 +1,29 @@
+//! Crate with tests for missing docs.
+
+#![deny(missing_docs)]
+
+use rstest::{fixture, rstest};
+
+/// Root fixture
+#[fixture]
+pub fn root() -> u32 {
+    21
+}
+
+/// Injection fixture
+#[fixture]
+pub fn injection(root: u32) -> u32 {
+    2 * root
+}
+
+/// Success test
+#[rstest]
+pub fn success(injection: u32) {
+    assert_eq!(42, injection);
+}
+
+/// Fail test
+#[rstest]
+pub fn fail(injection: u32) {
+    assert_eq!(41, injection);
+}

--- a/rstest_macros/src/render/fixture.rs
+++ b/rstest_macros/src/render/fixture.rs
@@ -97,16 +97,19 @@ pub(crate) fn render(mut fixture: ItemFn, info: FixtureInfo) -> TokenStream {
     }
 
     quote! {
+        #[doc(hidden)]
         #[allow(non_camel_case_types)]
         #visibility struct #name {}
 
         impl #name {
             #(#orig_attrs)*
+            #[doc(hidden)]
             #[allow(unused_mut)]
             pub #asyncness fn get #generics (#(#inner_args),*) #output #where_clause {
                 #call_impl
             }
 
+            #[doc(hidden)]
             pub #asyncness fn default #default_generics () #default_output #default_where_clause {
                 #inject
                 #call_get


### PR DESCRIPTION
When the `missing_docs` lint is enabled in a crate that uses `rstest` then any public `#[fixture]`s generate lint errors ("missing documentation for a struct" and "missing documentation for an associated function").

Use `#[doc(hidden)]` to hide these autogenerated items in documentation.

Just in case anyone has a better idea I'm all ears (e.g. adding some documentation to these items, or allowing missing_docs lint).

(For context, here is the original issue that sparked this PR: https://gitlab.archlinux.org/archlinux/signstar/-/merge_requests/230/diffs#note_268412)

Thanks and have a nice day! :wave: 