### PR TITLE
use wasm-bindgen feature of futures-timer for wasm{32/64}-unknown-unknown targets

### DIFF
--- a/rstest/Cargo.toml
+++ b/rstest/Cargo.toml
@@ -17,9 +17,9 @@ version = "0.25.0-dev"
 
 [features]
 async-timeout = [
-    "dep:futures-timer",
-    "dep:futures-util",
-    "rstest_macros/async-timeout",
+  "dep:futures-timer",
+  "dep:futures-util",
+  "rstest_macros/async-timeout",
 ]
 crate-name = ["rstest_macros/crate-name"]
 default = ["async-timeout", "crate-name"]
@@ -27,9 +27,16 @@ default = ["async-timeout", "crate-name"]
 [lib]
 
 [dependencies]
-futures-timer = { version = "3.0.3", optional = true }
 futures-util = { version = "0.3.30", optional = true }
 rstest_macros = { version = "0.25.0-dev", path = "../rstest_macros", default-features = false }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+futures-timer = { version = "3.0.3", optional = true }
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+futures-timer = { version = "3.0.3", optional = true, features = [
+  "wasm-bindgen",
+] }
 
 [dev-dependencies]
 actix-rt = "2.9.0"


### PR DESCRIPTION
Setting a timeout in wasm for tests is incredibly helpful, since the default test runner won't let you know when a wasm test is taking longer then expected, and instead might just hang CI without any messages for a very long time. using rstest timeouts is one workaround to this, and provides an easy way to tell which test is hanging. especially useful if there are lots of tests


Luckily, futures-timer already supports wasm, it must just be manually enabled with the `wasm-bindgen` feature