### PR TITLE
Add permission for empty_structs_with_brackets in fixture

### DIFF
--- a/rstest_macros/src/render/fixture.rs
+++ b/rstest_macros/src/render/fixture.rs
@@ -99,6 +99,7 @@ pub(crate) fn render(mut fixture: ItemFn, info: FixtureInfo) -> TokenStream {
     quote! {
         #[doc(hidden)]
         #[allow(non_camel_case_types)]
+        #[allow(clippy::empty_structs_with_brackets)]
         #visibility struct #name {}
 
         impl #name {


### PR DESCRIPTION
After the update, clippy gives new errors related to [empty_structs_with_brackets](https://rust-lang.github.io/rust-clippy/master/#empty_structs_with_brackets). I think it is worth noting at this point that in some cases it is acceptable for the structure to be empty. This solution does not change the logic of the box and eliminates unnecessary errors obtained when analyzing clippy.