### PR TITLE
Make #[files(...)] work on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,13 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        runs-on:
+        - ubuntu-latest
+        - windows-latest
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
@@ -33,11 +38,17 @@ jobs:
     - name: Build
       run: cargo build --all --verbose
     - name: Run tests stable
-      run: RSTEST_TEST_CHANNEL=stable cargo test --all --verbose
+      env:
+        RSTEST_TEST_CHANNEL: stable
+      run: cargo test --all --verbose
     - name: Run tests beta
-      run: RSTEST_TEST_CHANNEL=beta cargo test --all --verbose
+      env:
+        RSTEST_TEST_CHANNEL: beta
+      run: cargo test --all --verbose
     - name: Run tests nightly
-      run: RSTEST_TEST_CHANNEL=nightly cargo test --all --verbose
+      env:
+        RSTEST_TEST_CHANNEL: nightly
+      run: cargo test --all --verbose
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Removed unsued trait and impl spotted out on `1.89.0-nightly`
 - Add missed tests about ignore attribute's args in `rstest` expansion.
   See [#313](https://github.com/la10736/rstest/pull/313)
+- The `#[files(...)]` attribute now works reliably on Windows.
 
 ## [0.25.0] 2025/3/2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Introduced the `#[dirs]` attribute, which can be used with `#[files(...)]` to explicitly include directory paths.
   See [#306](https://github.com/la10736/rstest/pull/306) thanks to @Obito-git.
+- The CI now runs builds and tests on Windows, as well.
 
 ### Fixed
 

--- a/rstest/tests/fixture/mod.rs
+++ b/rstest/tests/fixture/mod.rs
@@ -5,6 +5,14 @@ use super::resources;
 use mytest::*;
 use rstest_test::{assert_in, assert_not_in, Project, Stringable, TestResults};
 
+const SRC_LIB_RS: &str = {
+    const SEP: u8 = std::path::MAIN_SEPARATOR as u8;
+    const SRC_LIB_RS: [u8; 11] = [
+        SEP, b's', b'r', b'c', SEP, b'l', b'i', b'b', b'.', b'r', b's',
+    ];
+    unsafe { std::str::from_utf8_unchecked(&SRC_LIB_RS) }
+};
+
 fn prj(res: &str) -> Project {
     let path = Path::new("fixture").join(res);
     crate::prj().set_code_file(resources(path))
@@ -242,7 +250,7 @@ mod should {
                 output.stderr.str(),
                 format!(
                     r#"
-                      --> {name}/src/lib.rs:14:33
+                      --> {name}{SRC_LIB_RS}:14:33
                        |
                     14 | fn error_cannot_resolve_fixture(no_fixture: u32) {{"#
                 )
@@ -259,7 +267,7 @@ mod should {
                 format!(
                     r#"
                     error[E0308]: mismatched types
-                      --> {name}/src/lib.rs:10:18
+                      --> {name}{SRC_LIB_RS}:10:18
                        |
                     10 |     let a: u32 = "";
                     "#
@@ -277,7 +285,7 @@ mod should {
                 format!(
                     r#"
                     error[E0308]: mismatched types
-                      --> {name}/src/lib.rs:17:29
+                      --> {name}{SRC_LIB_RS}:17:29
                     "#
                 )
                 .unindent()
@@ -301,7 +309,7 @@ mod should {
                 format!(
                     "
                     error: Missed argument: 'not_a_fixture' should be a test function argument.
-                      --> {name}/src/lib.rs:19:11
+                      --> {name}{SRC_LIB_RS}:19:11
                        |
                     19 | #[fixture(not_a_fixture(24))]
                        |           ^^^^^^^^^^^^^
@@ -320,7 +328,7 @@ mod should {
                 format!(
                     r#"
                     error: Duplicate argument: 'f' is already defined.
-                      --> {name}/src/lib.rs:32:23
+                      --> {name}{SRC_LIB_RS}:32:23
                        |
                     32 | #[fixture(f("first"), f("second"))]
                        |                       ^
@@ -339,7 +347,7 @@ mod should {
                 format!(
                     r#"
                     error: To destruct a fixture you should provide a path to resolve it by '#[from(...)]' attribute.
-                      --> {name}/src/lib.rs:48:35
+                      --> {name}{SRC_LIB_RS}:48:35
                        |
                     48 | fn error_destruct_without_resolve(T(a): T) {{}}
                        |                                   ^^^^^^^
@@ -358,7 +366,7 @@ mod should {
                 format!(
                     r#"
                     error: To destruct a fixture you should provide a path to resolve it by '#[from(...)]' attribute.
-                      --> {name}/src/lib.rs:51:57
+                      --> {name}{SRC_LIB_RS}:51:57
                        |
                     51 | fn error_destruct_without_resolve_also_with(#[with(21)] T(a): T) {{}}
                        |                                                         ^^^^^^^
@@ -395,11 +403,10 @@ mod should {
                 format!(
                     r#"
                     error: Cannot apply #[once] to async fixture.
-                     --> {}/src/lib.rs:4:1
+                     --> {name}{SRC_LIB_RS}:4:1
                       |
                     4 | #[once]
-                    "#,
-                    name
+                    "#
                 )
                 .unindent()
             );
@@ -414,11 +421,10 @@ mod should {
                 format!(
                     r#"
                     error: Cannot apply #[once] on generic fixture.
-                     --> {}/src/lib.rs:9:1
+                     --> {name}{SRC_LIB_RS}:9:1
                       |
                     9 | #[once]
-                    "#,
-                    name
+                    "#
                 )
                 .unindent()
             );
@@ -432,11 +438,10 @@ mod should {
                 format!(
                     r#"
                 error: Cannot apply #[once] on generic fixture.
-                  --> {}/src/lib.rs:15:1
+                  --> {name}{SRC_LIB_RS}:15:1
                    |
                 15 | #[once]
-                "#,
-                    name
+                "#
                 )
                 .unindent()
             );
@@ -450,12 +455,11 @@ mod should {
                 format!(
                     r#"
                     error[E0277]: `Cell<u32>` cannot be shared between threads safely
-                      --> {}/src/lib.rs:20:1
+                      --> {name}{SRC_LIB_RS}:20:1
                        |
                     20 | #[fixture]
                        | ^^^^^^^^^^ `Cell<u32>` cannot be shared between threads safely
-                    "#,
-                    name,
+                    "#
                 )
                 .unindent(),
             );

--- a/rstest_test/src/prj.rs
+++ b/rstest_test/src/prj.rs
@@ -192,7 +192,8 @@ impl Project {
     }
 
     pub fn add_path_dependency(&self, name: &str, path: &str) {
-        self.add_dependency(name, format!(r#"{{path="{path}"}}"#).as_str());
+        let path = crate::to_toml_string(path.to_string());
+        self.add_dependency(name, format!(r#"{{path={path}}}"#).as_str());
     }
 
     pub fn add_local_dependency(&self, name: &str) {

--- a/rstest_test/src/utils.rs
+++ b/rstest_test/src/utils.rs
@@ -376,6 +376,10 @@ where
     }
 }
 
+pub fn to_toml_string(str: String) -> String {
+    toml_edit::value(str).to_string()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
The resolver produces canonicalized paths, which have the verbatim path prefix `\\?\` on Windows. This caused the calculation of relative paths to break, resulting in strange test names being generated.

As a workaround, canonicalize the base path as well, so that it gets the prefix, too. This makes relative path resolution work again. As a consequence, though, we need to ignore not found errors during canonicalization. Some tests use fake resolvers which produce non-existing paths. Ignoring not found errors makes them pass.

Also, fix the tests so that they work on Windows. There have been many hard-coded slashes, and often, paths have been injected into contexts where backslashes need to be escaped, such as in TOML strings, regular expressions, or Rust code.

Fixes #287.