### PR TITLE
Disable default features of `futures-util`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 
--  Bump msrv to 1.82.0 
+- Bump msrv to 1.82.0
+- Disabled default features of `futures-util`
 
 ### Add
 

--- a/rstest/Cargo.toml
+++ b/rstest/Cargo.toml
@@ -28,7 +28,7 @@ default = ["async-timeout", "crate-name"]
 
 [dependencies]
 futures-timer = { version = "3.0.3", optional = true }
-futures-util = { version = "0.3.30", optional = true }
+futures-util = { version = "0.3.30", default-features = false, optional = true }
 rstest_macros = { version = "0.26.1-dev", path = "../rstest_macros", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This disables default features of futures-util, which can be quite heavy to compile, by replacing the `futures_util::select!` macro with `futures_util::future::select`. While at it, I've also removed the uses of `.fuse()` which didn't seem to help with anything.