### PR TITLE
Add a template for a group of methods from one module

### DIFF
--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -451,7 +451,43 @@ pub fn apply(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> T
     tokens.into()
 }
 
-#[allow(missing_docs)]
+/// Define a template for a group of methods located in module.
+///
+/// The template supports attribute #1 to mark methods that should be excluded from
+/// the template because they will contain implementation differences for specific cases.
+///
+/// ```
+/// #[rstest_reuse::template_group(template_tests)]
+/// mod tests {
+///     use rstest::rstest;
+///     use rstest_reuse::replace;
+///
+///     #[replace]
+///     fn version() -> u8 {
+///         unimplemented!()
+///     }
+///
+///     #[rstest]
+///     fn test() {
+///         let value = version();
+///         assert!(value > 0, "{} is not greater than 0", value)
+///     }
+/// }
+///
+/// #[rstest_reuse::apply_group(template_tests)]
+/// mod tests_first {
+///     fn version() -> u8 {
+///         1
+///     }
+/// }
+///
+/// #[rstest_reuse::apply_group(template_tests)]
+/// mod tests_seconds {
+///     fn version() -> u8 {
+///         2
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn template_group(
     args: proc_macro::TokenStream,
@@ -506,13 +542,43 @@ pub fn template_group(
     tokens.into()
 }
 
-#[allow(missing_docs)]
+/// Mark a method as requiring replacement with a different implementation.
+/// Used in conjunction with `#[template_group]`
 #[proc_macro_attribute]
 pub fn replace(_args: TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     input.into()
 }
 
-#[allow(missing_docs)]
+/// Apply a defined group template.
+///
+/// Example:
+///
+/// ```
+/// #[rstest_reuse::template_group(template_inner)]
+/// mod inner {
+///     use rstest::{rstest, fixture};
+///     use rstest_reuse::replace;
+///
+///     #[fixture]
+///     #[replace]
+///     fn fixture() -> u8 {
+///         unimplemented!()
+///     }
+///
+///     #[rstest]
+///     fn test(fixture: u8) {
+///         assert_eq!(fixture, 1)
+///     }
+/// }
+///
+/// #[rstest_reuse::apply_group(template_inner)]
+/// mod test {
+///     #[fixture]
+///     fn fixture() -> u8 {
+///         1
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn apply_group(args: TokenStream, input: TokenStream) -> TokenStream {
     let macro_name = parse_macro_input!(args as Path);

--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -454,12 +454,12 @@ pub fn apply(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> T
 #[allow(missing_docs)]
 #[proc_macro_attribute]
 pub fn template_group(
-    _args: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
+    let macro_name = parse_macro_input!(args as Path);
     let module = parse_macro_input!(input as ItemMod);
     let module_name = module.ident.clone();
-    let macro_name = format_ident!("{}", module_name.to_string());
 
     let Some((_, content)) = module.content.clone() else {
         return Error::new_spanned(
@@ -530,6 +530,8 @@ pub fn apply_group(args: TokenStream, input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         mod #module_name {
+            #![allow(unused_imports)]
+
             #(#module_content)*
             #macro_name!();
         }

--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -464,7 +464,7 @@ pub fn template_group(
     let Some((_, content)) = module.content.clone() else {
         return Error::new_spanned(
             module.ident,
-            "Cannot add tests to non-inline module. Use `mod name { ... }`",
+            "Cannot create template tests to non-inline module. Use `mod name { ... }`",
         )
         .to_compile_error()
         .into();

--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -194,7 +194,10 @@ use std::collections::HashMap;
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse, parse::Parse, parse_macro_input, Attribute, Ident, ItemFn, PatType, Path, Token};
+use syn::{
+    parse, parse::Parse, parse_macro_input, Attribute, Error, Ident, Item, ItemFn, ItemMod,
+    PatType, Path, Token,
+};
 
 struct MergeAttrs {
     template: ItemFn,
@@ -446,4 +449,89 @@ pub fn apply(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> T
         }
     };
     tokens.into()
+}
+
+#[allow(missing_docs)]
+#[proc_macro_attribute]
+pub fn template_group(
+    _args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let module = parse_macro_input!(input as ItemMod);
+    let module_name = module.ident.clone();
+    let macro_name = format_ident!("{}", module_name.to_string());
+
+    let Some((_, content)) = module.content.clone() else {
+        return Error::new_spanned(
+            module.ident,
+            "Cannot add tests to non-inline module. Use `mod name { ... }`",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let mut macro_context = Vec::with_capacity(content.len());
+    let mut module_context = Vec::with_capacity(content.len());
+
+    for item in content.iter() {
+        module_context.push(item);
+
+        if let Item::Fn(func) = item {
+            if func
+                .attrs
+                .iter()
+                .any(|attr| attr.path().is_ident(&format_ident!("{}", "replace")))
+            {
+                continue;
+            }
+        }
+
+        macro_context.push(item);
+    }
+
+    let tokens = quote! {
+        #[macro_export]
+        macro_rules! #macro_name {
+            () => {
+                #(#macro_context)*
+            }
+        }
+
+        #[cfg(test)]
+        pub mod #module_name {
+            #(#module_context)*
+        }
+    };
+
+    tokens.into()
+}
+
+#[allow(missing_docs)]
+#[proc_macro_attribute]
+pub fn replace(_args: TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    input.into()
+}
+
+#[allow(missing_docs)]
+#[proc_macro_attribute]
+pub fn apply_group(args: TokenStream, input: TokenStream) -> TokenStream {
+    let macro_name = parse_macro_input!(args as Path);
+    let module = parse_macro_input!(input as ItemMod);
+    let module_name = module.ident.clone();
+
+    let Some((_, module_content)) = module.content else {
+        return Error::new_spanned(
+            module.ident,
+            "Cannot add tests to non-inline module. Use `mod name { ... }`",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    TokenStream::from(quote! {
+        mod #module_name {
+            #(#module_content)*
+            #macro_name!();
+        }
+    })
 }

--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -453,8 +453,10 @@ pub fn apply(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> T
 
 /// Define a template for a group of methods located in module.
 ///
-/// The template supports attribute #1 to mark methods that should be excluded from
+/// The template supports attribute `#[replace]` to mark methods that should be excluded from
 /// the template because they will contain implementation differences for specific cases.
+///
+/// Example:
 ///
 /// ```
 /// #[rstest_reuse::template_group(template_tests)]
@@ -464,7 +466,7 @@ pub fn apply(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> T
 ///
 ///     #[replace]
 ///     fn version() -> u8 {
-///         unimplemented!()
+///         1
 ///     }
 ///
 ///     #[rstest]
@@ -477,14 +479,14 @@ pub fn apply(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> T
 /// #[rstest_reuse::apply_group(template_tests)]
 /// mod tests_first {
 ///     fn version() -> u8 {
-///         1
+///         2
 ///     }
 /// }
 ///
 /// #[rstest_reuse::apply_group(template_tests)]
 /// mod tests_seconds {
 ///     fn version() -> u8 {
-///         2
+///         3
 ///     }
 /// }
 /// ```
@@ -562,12 +564,12 @@ pub fn replace(_args: TokenStream, input: proc_macro::TokenStream) -> proc_macro
 ///     #[fixture]
 ///     #[replace]
 ///     fn fixture() -> u8 {
-///         unimplemented!()
+///         1
 ///     }
 ///
 ///     #[rstest]
 ///     fn test(fixture: u8) {
-///         assert_eq!(fixture, 1)
+///         assert!(fixture > 0, "{} is not greater than 0", fixture)
 ///     }
 /// }
 ///
@@ -575,7 +577,7 @@ pub fn replace(_args: TokenStream, input: proc_macro::TokenStream) -> proc_macro
 /// mod test {
 ///     #[fixture]
 ///     fn fixture() -> u8 {
-///         1
+///         2
 ///     }
 /// }
 /// ```

--- a/rstest_reuse/src/lib.rs
+++ b/rstest_reuse/src/lib.rs
@@ -42,7 +42,6 @@
 //!     assert!(a == b);
 //! }
 //!
-//!
 //! // Here we reuse the `two_simple_cases` template to create two
 //! // other tests
 //! #[apply(two_simple_cases)]

--- a/rstest_reuse/tests/acceptance.rs
+++ b/rstest_reuse/tests/acceptance.rs
@@ -163,6 +163,16 @@ fn use_same_name_for_more_templates() {
 }
 
 #[test]
+fn use_template_for_group() {
+    let (output, _) = run_test("template_group.rs");
+
+    TestResults::new()
+        .ok("inner::test")
+        .fail("template_example::test")
+        .assert(output);
+}
+
+#[test]
 fn no_local_macro_should_not_compile() {
     let (output, _) = run_test("no_local_macro_should_not_compile.rs");
 

--- a/rstest_reuse/tests/acceptance.rs
+++ b/rstest_reuse/tests/acceptance.rs
@@ -163,8 +163,28 @@ fn use_same_name_for_more_templates() {
 }
 
 #[test]
-fn use_template_for_group() {
+fn use_template_group() {
     let (output, _) = run_test("template_group.rs");
+
+    TestResults::new()
+        .ok("inner::test")
+        .fail("inner1::test")
+        .assert(output);
+}
+
+#[test]
+fn use_template_group_with_replace() {
+    let (output, _) = run_test("template_group_with_replace.rs");
+
+    TestResults::new()
+        .ok("inner::test")
+        .fail("inner1::test")
+        .assert(output);
+}
+
+#[test]
+fn use_template_group_with_replace_fixture() {
+    let (output, _) = run_test("template_group_with_replace_fixture.rs");
 
     TestResults::new()
         .ok("inner::test")

--- a/rstest_reuse/tests/acceptance.rs
+++ b/rstest_reuse/tests/acceptance.rs
@@ -168,7 +168,7 @@ fn use_template_for_group() {
 
     TestResults::new()
         .ok("inner::test")
-        .fail("template_example::test")
+        .fail("inner1::test")
         .assert(output);
 }
 

--- a/rstest_reuse/tests/resources/template_group.rs
+++ b/rstest_reuse/tests/resources/template_group.rs
@@ -1,5 +1,5 @@
-#[rstest_reuse::template_group]
-pub mod template_example {
+#[rstest_reuse::template_group(template_example)]
+pub mod inner1 {
     use rstest::rstest;
     use rstest_reuse::replace;
 

--- a/rstest_reuse/tests/resources/template_group.rs
+++ b/rstest_reuse/tests/resources/template_group.rs
@@ -1,0 +1,23 @@
+#[rstest_reuse::template_group]
+pub mod template_example {
+    use rstest::rstest;
+    use rstest_reuse::replace;
+
+    #[replace]
+    fn prepare() -> u32 {
+        unimplemented!()
+    }
+
+    #[rstest]
+    fn test() {
+        let value = prepare();
+        assert_eq!(value, 0);
+    }
+}
+
+#[rstest_reuse::apply_group(template_example)]
+pub mod inner {
+    fn prepare() -> u32 {
+        0
+    }
+}

--- a/rstest_reuse/tests/resources/template_group_with_replace.rs
+++ b/rstest_reuse/tests/resources/template_group_with_replace.rs
@@ -1,0 +1,23 @@
+#[rstest_reuse::template_group(template_inner)]
+mod inner1 {
+    use rstest::rstest;
+    use rstest_reuse::replace;
+
+    #[replace]
+    fn prepare() -> u8 {
+        unimplemented!()
+    }
+
+    #[rstest]
+    fn test() {
+        let value = prepare();
+        assert!(value > 0, "{} is not greater than 0", value)
+    }
+}
+
+#[rstest_reuse::apply_group(template_inner)]
+mod inner {
+    fn prepare() -> u8 {
+        1
+    }
+}

--- a/rstest_reuse/tests/resources/template_group_with_replace_fixture.rs
+++ b/rstest_reuse/tests/resources/template_group_with_replace_fixture.rs
@@ -1,0 +1,24 @@
+#[rstest_reuse::template_group(template_inner)]
+mod inner1 {
+    use rstest::{fixture, rstest};
+    use rstest_reuse::replace;
+
+    #[fixture]
+    #[replace]
+    fn fixture() -> u8 {
+        unimplemented!()
+    }
+
+    #[rstest]
+    fn test(fixture: u8) {
+        assert!(fixture > 0, "{} is not greater than 0", fixture)
+    }
+}
+
+#[rstest_reuse::apply_group(template_inner)]
+mod inner {
+    #[fixture]
+    fn fixture() -> u8 {
+        1
+    }
+}


### PR DESCRIPTION
I'd like to share a solution to the problem of writing identical tests.

My project uses multiple implementations of the same trait. All tests have the same logic for verifying the behavior of the trait implementation; the only difference is in the `#[fixture]` section, where the implementation under test is selected.

The solution I propose is similar to `#[template]`, except that we create a template for the entire module and, in this module, mark the methods that should be excluded from the template. The excluded methods are expected to be implemented with the necessary modifications wherever the template is used.