### PR TITLE
fix: Use fully-qualified core import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ### Fixed
 
--  Fix compilation under bazel by upgrading proc-macro-crate to 3.4.0
+- Use fully-qualified `core` import. See [#336](https://github.com/la10736/rstest/pull/336).
+- Fix compilation under bazel by upgrading proc-macro-crate to 3.4.0.
 
 ## [0.26.1] 2025/7/27
 

--- a/rstest_macros/src/render/apply_arguments.rs
+++ b/rstest_macros/src/render/apply_arguments.rs
@@ -118,7 +118,7 @@ impl ImplFutureArg for FnArg {
             Some(ty) => {
                 let lifetime = update_type_with_lifetime(ty, lifetime_id);
                 *ty = parse_quote! {
-                    impl core::future::Future<Output = #ty>
+                    impl ::core::future::Future<Output = #ty>
                 };
                 self.remove_mutability();
                 lifetime
@@ -166,30 +166,30 @@ mod should {
     #[case::simple(
         "fn f(a: u32) {}",
         &["a"],
-        "fn f(a: impl core::future::Future<Output = u32>) {}"
+        "fn f(a: impl ::core::future::Future<Output = u32>) {}"
     )]
     #[case::more_than_one(
         "fn f(a: u32, b: String, c: std::collection::HashMap<usize, String>) {}",
         &["a", "b", "c"],
-        r#"fn f(a: impl core::future::Future<Output = u32>, 
-                b: impl core::future::Future<Output = String>, 
-                c: impl core::future::Future<Output = std::collection::HashMap<usize, String>>) {}"#,
+        r#"fn f(a: impl ::core::future::Future<Output = u32>,
+                b: impl ::core::future::Future<Output = String>,
+                c: impl ::core::future::Future<Output = std::collection::HashMap<usize, String>>) {}"#,
     )]
     #[case::just_one(
         "fn f(a: u32, b: String) {}",
         &["b"],
-        r#"fn f(a: u32, 
-                b: impl core::future::Future<Output = String>) {}"#
+        r#"fn f(a: u32,
+                b: impl ::core::future::Future<Output = String>) {}"#
     )]
     #[case::generics(
         "fn f<S: AsRef<str>>(a: S) {}",
         &["a"],
-        "fn f<S: AsRef<str>>(a: impl core::future::Future<Output = S>) {}"
+        "fn f<S: AsRef<str>>(a: impl ::core::future::Future<Output = S>) {}"
     )]
     #[case::remove_mut(
         "fn f(mut a: u32) {}",
         &["a"],
-        r#"fn f(a: impl core::future::Future<Output = u32>) {}"#
+        r#"fn f(a: impl ::core::future::Future<Output = u32>) {}"#
     )]
     fn replace_future_basic_type(
         #[case] item_fn: &str,
@@ -213,17 +213,17 @@ mod should {
     #[case::base(
         "fn f(ident_name: &u32) {}",
         &["ident_name"],
-        "fn f<'_ident_name>(ident_name: impl core::future::Future<Output = &'_ident_name u32>) {}"
+        "fn f<'_ident_name>(ident_name: impl ::core::future::Future<Output = &'_ident_name u32>) {}"
     )]
     #[case::lifetime_already_exists(
         "fn f<'b>(a: &'b u32) {}",
         &["a"],
-        "fn f<'b>(a: impl core::future::Future<Output = &'b u32>) {}"
+        "fn f<'b>(a: impl ::core::future::Future<Output = &'b u32>) {}"
     )]
     #[case::some_other_generics(
         "fn f<'b, IT: Iterator<Item=String + 'b>>(a: &u32, it: IT) {}",
         &["a"],
-        "fn f<'_a, 'b, IT: Iterator<Item=String + 'b>>(a: impl core::future::Future<Output = &'_a u32>, it: IT) {}"
+        "fn f<'_a, 'b, IT: Iterator<Item=String + 'b>>(a: impl ::core::future::Future<Output = &'_a u32>, it: IT) {}"
     )]
     fn replace_reference_type(
         #[case] item_fn: &str,

--- a/rstest_macros/src/render/fixture.rs
+++ b/rstest_macros/src/render/fixture.rs
@@ -265,7 +265,7 @@ mod should {
         let item_fn = parse_str::<ItemFn>(r#"
                 pub fn test<R: AsRef<str>, B>(mut s: String, v: &u32, a: &mut [i32], r: R) -> (u32, B, String, &str)
                             where B: Borrow<u32>
-                    { }    
+                    { }
         "#).unwrap();
         let info = FixtureInfo::default().with_once();
 
@@ -541,8 +541,8 @@ mod should {
         let expected = parse_str::<syn::ItemFn>(
             r#"
                     async fn get<'_async_ref_u32>(
-                        async_ref_u32: impl core::future::Future<Output = &'_async_ref_u32 u32>, 
-                        async_u32: impl core::future::Future<Output = u32>, 
+                        async_ref_u32: impl ::core::future::Future<Output = &'_async_ref_u32 u32>,
+                        async_u32: impl ::core::future::Future<Output = u32>,
                         simple: u32
                     )
                     { }

--- a/rstest_macros/src/render/inject.rs
+++ b/rstest_macros/src/render/inject.rs
@@ -110,7 +110,7 @@ fn handling_magic_conversion_code(fixture: Cow<Expr>, arg_type: &Type) -> Expr {
     parse_quote! {
         {
             use #rstest_path::magic_conversion::*;
-            (&&&Magic::<#arg_type>(core::marker::PhantomData)).magic_conversion(#fixture)
+            (&&&Magic::<#arg_type>(::core::marker::PhantomData)).magic_conversion(#fixture)
         }
     }
 }
@@ -215,7 +215,7 @@ mod should {
         0,
         "let arg = {
             use rstest::magic_conversion::*;
-            (&&&Magic::<MyType>(core::marker::PhantomData)).magic_conversion(\"value to convert\")
+            (&&&Magic::<MyType>(::core::marker::PhantomData)).magic_conversion(\"value to convert\")
         };"
     )]
     #[case::discard_impl(
@@ -233,7 +233,7 @@ mod should {
         0,
         "let arg = {
             use rstest::magic_conversion::*;
-            (&&&Magic::<&MyType>(core::marker::PhantomData)).magic_conversion(\"value to convert\")
+            (&&&Magic::<&MyType>(::core::marker::PhantomData)).magic_conversion(\"value to convert\")
         };"
     )]
     #[case::mutable_reference_type(
@@ -241,7 +241,7 @@ mod should {
         0,
         "let arg = {
             use rstest::magic_conversion::*;
-            (&&&Magic::<&mut MyType>(core::marker::PhantomData)).magic_conversion(\"value to convert\")
+            (&&&Magic::<&mut MyType>(::core::marker::PhantomData)).magic_conversion(\"value to convert\")
         };"
     )]
     #[case::generic_type_with_lifetime(
@@ -249,7 +249,7 @@ mod should {
         0,
         "let arg = {
             use rstest::magic_conversion::*;
-            (&&&Magic::<&'a T>(core::marker::PhantomData)).magic_conversion(\"value to convert\")
+            (&&&Magic::<&'a T>(::core::marker::PhantomData)).magic_conversion(\"value to convert\")
         };"
     )]
     #[case::type_with_generic_parameters(
@@ -257,7 +257,7 @@ mod should {
         0,
         "let arg = {
             use rstest::magic_conversion::*;
-            (&&&Magic::<Option<MyType>>(core::marker::PhantomData)).magic_conversion(\"value to convert\")
+            (&&&Magic::<Option<MyType>>(::core::marker::PhantomData)).magic_conversion(\"value to convert\")
         };"
     )]
     #[case::complex_type(
@@ -265,7 +265,7 @@ mod should {
         0,
         "let arg = {
             use rstest::magic_conversion::*;
-            (&&&Magic::<Result<Vec<MyType>, MyError>>(core::marker::PhantomData)).magic_conversion(\"value to convert\")
+            (&&&Magic::<Result<Vec<MyType>, MyError>>(::core::marker::PhantomData)).magic_conversion(\"value to convert\")
         };"
     )]
     fn generated_code_uses_phantom_data(

--- a/rstest_macros/src/render/mod.rs
+++ b/rstest_macros/src/render/mod.rs
@@ -28,10 +28,10 @@ use crate::{
 };
 use wrapper::WrapByModule;
 
-pub(crate) use fixture::render as fixture;
-use crate::parse::arguments::TestAttr;
 use self::apply_arguments::ApplyArguments;
 use self::crate_resolver::crate_name;
+use crate::parse::arguments::TestAttr;
+pub(crate) use fixture::render as fixture;
 pub(crate) mod apply_arguments;
 pub(crate) mod inject;
 
@@ -208,20 +208,14 @@ pub(crate) fn matrix(mut test: ItemFn, mut info: RsTestInfo) -> TokenStream {
     test_group(test, rendered_cases)
 }
 
-fn resolve_test_attr(
-    test_attr: Option<&TestAttr>,
-) -> Option<TokenStream> {
+fn resolve_test_attr(test_attr: Option<&TestAttr>) -> Option<TokenStream> {
     match test_attr {
-        Some(TestAttr::Explicit(attr)) => {
-            Some(quote! { #attr })
-        }
+        Some(TestAttr::Explicit(attr)) => Some(quote! { #attr }),
         Some(TestAttr::InAttrs) => {
             // test attr is already in the attributes; we don't need to re-inject it
             None
         }
-        None => {
-            Some(quote! { #[test] })
-        }
+        None => Some(quote! { #[test] }),
     }
 }
 
@@ -242,7 +236,7 @@ fn render_test_call(
     let timeout = timeout.map(|x| quote! {#x}).or_else(|| {
         std::env::var("RSTEST_TIMEOUT")
             .ok()
-            .map(|to| quote! { core::time::Duration::from_secs( (#to).parse().unwrap()) })
+            .map(|to| quote! { ::core::time::Duration::from_secs( (#to).parse().unwrap()) })
     });
     let rstest_path = crate_name();
     match (timeout, is_async) {
@@ -376,10 +370,9 @@ fn single_test_case(
     let lifetimes = if lifetimes.peek().is_some() {
         Some(quote! {<#(#lifetimes,)*>})
     } else {
-       None 
+        None
     };
-    
-    
+
     quote! {
         #(#attrs)*
         #test_attr

--- a/rstest_macros/src/render/test.rs
+++ b/rstest_macros/src/render/test.rs
@@ -332,8 +332,8 @@ mod single_test_should {
 
         let expected = parse_str::<syn::ItemFn>(
             r#"async fn test<'_async_ref_u32>(
-                        async_ref_u32: impl core::future::Future<Output = &'_async_ref_u32 u32>,
-                        async_u32: impl core::future::Future<Output = u32>,
+                        async_ref_u32: impl ::core::future::Future<Output = &'_async_ref_u32 u32>,
+                        async_u32: impl ::core::future::Future<Output = u32>,
                         simple: u32
                     )
                     { }
@@ -922,8 +922,8 @@ mod cases_should {
 
         let expected = parse_str::<syn::ItemFn>(
             r#"async fn test<'_async_ref_u32>(
-                        async_ref_u32: impl core::future::Future<Output = &'_async_ref_u32 u32>,
-                        async_u32: impl core::future::Future<Output = u32>,
+                        async_ref_u32: impl ::core::future::Future<Output = &'_async_ref_u32 u32>,
+                        async_u32: impl ::core::future::Future<Output = u32>,
                         simple: u32
                     )
                     { }
@@ -1333,8 +1333,8 @@ mod matrix_cases_should {
         let mut item_fn: ItemFn = r#"fn test(v: u32) {{ println!("user code") }}"#.ast();
         item_fn.set_async(is_async);
         item_fn.attrs = attributes.clone();
-        let mut info : RsTestInfo = data.into();
-        info.arguments.set_test_attr(Some(TestAttr::InAttrs));        
+        let mut info: RsTestInfo = data.into();
+        info.arguments.set_test_attr(Some(TestAttr::InAttrs));
 
         let tokens = matrix(item_fn, info);
 
@@ -1408,8 +1408,8 @@ mod matrix_cases_should {
 
         let expected = parse_str::<syn::ItemFn>(
             r#"async fn test<'_async_ref_u32>(
-                        async_ref_u32: impl core::future::Future<Output = &'_async_ref_u32 u32>,
-                        async_u32: impl core::future::Future<Output = u32>,
+                        async_ref_u32: impl ::core::future::Future<Output = &'_async_ref_u32 u32>,
+                        async_u32: impl ::core::future::Future<Output = u32>,
                         simple: u32
                     )
                     { }
@@ -1978,7 +1978,9 @@ mod test_attribute_should {
         let mut out = String::from("#[rstest]\n");
         match attr_style {
             TestAttrStyle::Explicit => {
-                info.arguments.set_test_attr(Some(TestAttr::Explicit(attr("#[my_explicit_test_attr]").into())));
+                info.arguments.set_test_attr(Some(TestAttr::Explicit(
+                    attr("#[my_explicit_test_attr]").into(),
+                )));
             }
             TestAttrStyle::Implicit => {
                 info.arguments.set_test_attr(Some(TestAttr::InAttrs));


### PR DESCRIPTION
If a local module is named "core", rstest will try to use the local "core" module, instead of using Rust's core module/library. This leads to compilation errors.

This PR prefixes all occurrences of `core` in the generated code with `::core` to always refer to Rust's core library.

This PR additionally seems to correct some formatting issues which were present before.

I've ran the complete test suite (using `cargo test`) and everything was green. Let me know, if there are any additional tests which need to be run to ensure nothing breaks.